### PR TITLE
Feature/arm64 compatibility (#48)

### DIFF
--- a/.github/workflows/cd.yaml
+++ b/.github/workflows/cd.yaml
@@ -1,0 +1,28 @@
+name: CD
+
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Log in to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build Docker image
+        run: |
+          docker build -t crab-track:${{ github.event.release.tag_name }} .
+
+      - name: Push Docker image
+        run: |
+          docker tag crab-track:${{ github.event.release.tag_name }} ${{ secrets.DOCKER_USERNAME }}/crab-track:${{ github.event.release.tag_name }}
+          docker push ${{ secrets.DOCKER_USERNAME }}/crab-track:${{ github.event.release.tag_name }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,4 +1,4 @@
-name: Python CI/CD
+name: CI
 
 on:
   push:
@@ -10,7 +10,7 @@ on:
       - main
 
 jobs:
-  build-and-test:
+  test:
     runs-on: ubuntu-latest
 
     steps:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.10.12-slim
+FROM --platform=linux/x86_64 python:3.10.12-slim
 RUN apt update && apt install -y libgl1 libglib2.0-0
 WORKDIR /app
 COPY requirements.txt requirements.txt

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,13 +4,15 @@ services:
     image: crab-track-image:0.1.0
     container_name: crab-track
     tty: false
-    shm_size: '4g'
+#    shm_size: '1g'
     volumes:
       - type: bind
-#        source: /home/matias/workspace/datasets/ICMAN-30-Octubre-2022
-        source: /home/matias/workspace/datasets/sample_dataset_icman
+        source: /home/matias/workspace/datasets/ICMAN-30-Octubre-2022
+#        source: /Users/matiasgonzalez/workspace/datasets/sample_dataset_icman
+#        source: /home/matias/workspace/datasets/sample_dataset_icman
         target: /dataset/samples
       - type: bind
+#        source: /Users/matiasgonzalez/crab-track-app/results
         source: /home/matias/workspace/crab-track-app/results
         target: /results
     environment:


### PR DESCRIPTION
* force amd64 emulation when running in a arm64 architecture

* build docker image when creating a release now the docker image is forced to be amd64 archicture it will work using emulation on a amr64 system